### PR TITLE
Ensure checks for `nvim`, `lvim` occur with right `PATH`

### DIFF
--- a/dropbox/env.sh
+++ b/dropbox/env.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 
-_dir="$HOME/Dropbox"
-if [ -d "$_dir" ]; then
-	export PATH_DROPBOX="$_dir"
-fi
+case "$(uname -s)" in
+Darwin*)
+	_dir="$HOME/Dropbox"
+	if [ -d "$_dir" ]; then
+		export PATH_DROPBOX="$_dir"
+	fi
+	;;
+Linux*) ;;
+*) echo "$(date '+%Y-%m-%d %H:%M:%S'): Invalid OS: $(uname -s)..." ;;
+esac

--- a/lunarvim/env.sh
+++ b/lunarvim/env.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+_bin="$HOME/.local/bin"
+if [ -d "$_bin" ]; then
+	export PATH="$_bin${PATH:+:$PATH}"
+fi
 if [ -x "$(command -v lvim)" ]; then
 	export EDITOR=lvim
 fi

--- a/neovim/env.sh
+++ b/neovim/env.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+_bin="$HOME/.local/bin"
+if [ -d "$_bin" ]; then
+	export PATH="$_bin${PATH:+:$PATH}"
+fi
 if [ -x "$(command -v nvim)" ] && ! [ -x "$(command -v lvim)" ]; then
 	export EDITOR=nvim
 fi

--- a/sh/source-all-files.sh
+++ b/sh/source-all-files.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-for name in env aliases config autocomplete; do
-	while IFS= read -r -d '' file; do
+for _name in env aliases config autocomplete; do
+	while IFS= read -r -d '' _file; do
 		# shellcheck source=/dev/null
-		source "$file"
-	done < <(find "$HOME/dotfiles" -type f -name "$name.sh" -print0)
+		source "$_file"
+	done < <(find "$HOME/dotfiles" -type f -name "$_name.sh" -print0)
 done


### PR DESCRIPTION
- Guard `dropbox` env on various machines
- Check for `~/.local/bin` in `lunarvim` env
- lower case some vars
- Also guard `neovim`
